### PR TITLE
[libsf] fix empty items sending and session expiration parsing

### DIFF
--- a/pkg/libsf/item.go
+++ b/pkg/libsf/item.go
@@ -25,21 +25,21 @@ type (
 	SyncItems struct {
 		// Common fields
 		API              string `json:"api"` // Since 20190520
-		ComputeIntegrity bool   `json:"compute_integrity"`
-		Limit            int    `json:"limit"`
-		SyncToken        string `json:"sync_token"`
-		CursorToken      string `json:"cursor_token"`
-		ContentType      string `json:"content_type"` // optional, only return items of these type if present
+		ComputeIntegrity bool   `json:"compute_integrity,omitempty"`
+		Limit            int    `json:"limit,omitempty"`
+		SyncToken        string `json:"sync_token,omitempty"`
+		CursorToken      string `json:"cursor_token,omitempty"`
+		ContentType      string `json:"content_type,omitempty"` // optional, only return items of these type if present
 
 		// Fields used for request
-		Items []*Item `json:"items"`
+		Items []*Item `json:"items,omitempty"`
 
 		// Fields used in response
-		Retrieved []*Item `json:"retrieved_items"`
-		Saved     []*Item `json:"saved_items"`
+		Retrieved []*Item `json:"retrieved_items,omitempty"`
+		Saved     []*Item `json:"saved_items,omitempty"`
 
-		Unsaved   []*UnsavedItem  `json:"unsaved"`   // Before 20190520 (Since 20161215 at least)
-		Conflicts []*ConflictItem `json:"conflicts"` // Since 20190520
+		Unsaved   []*UnsavedItem  `json:"unsaved,omitempty"`   // Before 20190520 (Since 20161215 at least)
+		Conflicts []*ConflictItem `json:"conflicts,omitempty"` // Since 20190520
 	}
 
 	// An Item holds all the data created by end user.

--- a/pkg/libsf/session.go
+++ b/pkg/libsf/session.go
@@ -1,6 +1,11 @@
 package libsf
 
-import "time"
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
 
 // A Session contains details about a session.
 type Session struct {
@@ -29,4 +34,42 @@ func (s Session) AccessExpired() bool {
 // RefreshExpired returns true if the refresh token is expired.
 func (s Session) RefreshExpired() bool {
 	return !s.Defined() || time.Now().After(s.RefreshExpiration)
+}
+
+type sessionTime time.Time
+
+func (t *sessionTime) UnmarshalJSON(s []byte) error {
+	r := strings.Replace(string(s), `"`, ``, -1)
+	tt, err := time.Parse(time.RFC3339, r)
+	if err != nil {
+		q, err := strconv.ParseInt(string(s), 10, 64)
+		if err != nil {
+			return err
+		}
+		*(*time.Time)(t) = time.Unix(q/1000, 0)
+		return nil
+	}
+	*(*time.Time)(t) = tt
+	return nil
+}
+
+func (s *Session) UnmarshalJSON(raw []byte) error {
+	st := &struct {
+		AccessToken       string      `json:"access_token"`
+		RefreshToken      string      `json:"refresh_token"`
+		AccessExpiration  sessionTime `json:"access_expiration"`
+		RefreshExpiration sessionTime `json:"refresh_expiration"`
+	}{}
+
+	err := json.Unmarshal(raw, st)
+	if err != nil {
+		return err
+	}
+
+	s.AccessToken = st.AccessToken
+	s.RefreshToken = st.RefreshToken
+	s.AccessExpiration = time.Time(st.AccessExpiration)
+	s.RefreshExpiration = time.Time(st.RefreshExpiration)
+
+	return nil
 }

--- a/pkg/libsf/session.go
+++ b/pkg/libsf/session.go
@@ -39,14 +39,15 @@ func (s Session) RefreshExpired() bool {
 type sessionTime time.Time
 
 func (t *sessionTime) UnmarshalJSON(s []byte) error {
-	r := strings.Replace(string(s), `"`, ``, -1)
+	r := strings.ReplaceAll(string(s), `"`, ``)
 	tt, err := time.Parse(time.RFC3339, r)
+
 	if err != nil {
 		q, err := strconv.ParseInt(string(s), 10, 64)
 		if err != nil {
 			return err
 		}
-		*(*time.Time)(t) = time.Unix(q/1000, 0)
+		*(*time.Time)(t) = time.Unix(0, q*1000000)
 		return nil
 	}
 	*(*time.Time)(t) = tt


### PR DESCRIPTION
I'm using libsf with official [syncing-server](https://github.com/standardnotes/syncing-server) and having some issues with it:
- empty `items` field on first sync causes empty sync response
- session endpoints returns time in unix format instead of RFC3339

solutions:
- omitempty request fields
- unmarshal both unix and RFC3339 time formats

I'm not sure about necessity of it maybe I should create issue to discuss first :) 