### PR TITLE
PKCE login implementation

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -21,6 +21,7 @@ type (
 		UserInteraction
 		SessionInteraction
 		ItemInteraction
+		PKCEInteraction
 	}
 
 	// An UserInteraction defines all the methods used to interact with a user record.
@@ -61,5 +62,10 @@ type (
 		FindItemsForIntegrityCheck(userID string) ([]*model.Item, error)
 		// DeleteItem deletes the item matching the given parameters.
 		DeleteItem(id, userID string) error
+	}
+
+	PKCEInteraction interface {
+		StorePKCE(codeChallenge string) error
+		RemovePKCE(codeChallenge string) (bool, error)
 	}
 )

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -66,7 +66,8 @@ type (
 
 	PKCEInteraction interface {
 		StorePKCE(codeChallenge string) error
-		RemovePKCE(codeChallenge string) (bool, error)
-		DeleteExpiredChallenges() error
+		RemovePKCE(codeChallenge string) error
+		CheckPKCE(codeChallenge string) error
+		RevokeExpiredChallenges() error
 	}
 )

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -67,5 +67,6 @@ type (
 	PKCEInteraction interface {
 		StorePKCE(codeChallenge string) error
 		RemovePKCE(codeChallenge string) (bool, error)
+		DeleteExpiredChallenges() error
 	}
 )

--- a/internal/database/storm.go
+++ b/internal/database/storm.go
@@ -238,29 +238,40 @@ func (c *strm) DeleteItem(id, userID string) error {
 	return errors.Wrap(err, "could not delete item")
 }
 
+func (c *strm) DeleteExpiredChallenges() error {
+	err := c.db.Select(q.Lte("ExpireAt", time.Now().UTC())).Delete(&model.PKCE{})
+	if err != nil && !c.IsNotFound(err) {
+		return errors.Wrap(err, "could not delete expired challenges")
+	}
+	return nil
+}
+
 func (c *strm) StorePKCE(codeChallenge string) error {
+	err := c.DeleteExpiredChallenges()
+	if err != nil {
+		return err
+	}
 	pkce := &model.PKCE{
 		CodeChallenge: codeChallenge,
 		ExpireAt:      time.Now().Add(1 * time.Hour).UTC(),
 	}
-	err := c.Save(pkce)
+	err = c.Save(pkce)
 	return err
 }
 
 func (c *strm) RemovePKCE(codeChallenge string) (bool, error) {
-	items := make([]*model.PKCE, 0)
-	// We remove expired challenges
-	err := c.db.Select(q.Lte("ExpireAt", time.Now().UTC())).Delete(&model.PKCE{})
-	if err != nil && !c.IsNotFound(err) {
-		return false, errors.Wrap(err, "could not delete challenges")
+	err := c.DeleteExpiredChallenges()
+	if err != nil {
+		return false, err
 	}
+	challenges := make([]*model.PKCE, 0)
 	// Then we look if there's a match
 	query := c.db.Select(q.Eq("CodeChallenge", codeChallenge))
-	err = query.Find(&items)
+	err = query.Find(&challenges)
 	if err != nil && !c.IsNotFound(err) {
 		return false, errors.Wrap(err, "could not find challenges")
 	}
-	matched := len(items) > 0
+	matched := len(challenges) > 0
 	// Then we delete matched items
 	err = query.Delete(&model.PKCE{})
 	if err != nil && !c.IsNotFound(err) {

--- a/internal/model/pkce.go
+++ b/internal/model/pkce.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"time"
+)
+
+// A PKCE represents a database record.
+type PKCE struct {
+	Base `msgpack:",inline" storm:"inline"`
+
+	CodeChallenge string    `msgpack:"code_challenge"       storm:"index"`
+	ExpireAt      time.Time `msgpack:"expire_at"`
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -131,6 +131,11 @@ func EchoEngine(ctrl Controller) *echo.Echo {
 
 	v1restricted.POST("/items", item.Sync)
 
+	v2 := router.Group("/v2")
+	v2.POST("/login", auth.LoginPKCE)
+	v2.POST("/login-params", auth.ParamsPKCE)
+	//v2restricted := restricted.Group("/v2")
+
 	return engine
 }
 
@@ -142,6 +147,8 @@ func PrintRoutes(e *echo.Echo) {
 		"/*":    true,
 		"/v1":   true,
 		"/v1/*": true,
+		"/v2":   true,
+		"/v2/*": true,
 	}
 
 	routes := e.Routes()

--- a/internal/server/service/pkce.go
+++ b/internal/server/service/pkce.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/mdouchement/standardfile/internal/database"
+)
+
+type (
+	// A PKCEService is a service used for managing challenges.
+	PKCEService interface {
+		ComputeChallenge(code_verifier string) string
+		StoreChallenge(code_challenge string) error
+		CheckChallenge(code_challenge string) error
+	}
+
+	pkceService struct {
+		db     database.Client
+		Params Params `json:"-"`
+	}
+)
+
+func NewPKCE(db database.Client, params Params) (s PKCEService) {
+	switch params.APIVersion { // for future API increments
+	default:
+		s = &pkceService{
+			db:     db,
+			Params: params,
+		}
+	}
+	return s
+}
+
+func (s *pkceService) ComputeChallenge(code_verifier string) string {
+	hash := sha256.Sum256([]byte(code_verifier))
+	hex_hash := fmt.Sprintf("%x", hash[:])
+	return base64.RawStdEncoding.EncodeToString([]byte(hex_hash))
+}
+
+func (s *pkceService) StoreChallenge(code_challenge string) error {
+	if err := s.db.RevokeExpiredChallenges(); err != nil {
+		return err
+	}
+	return s.db.StorePKCE(code_challenge)
+}
+
+func (s *pkceService) CheckChallenge(code_challenge string) error {
+	if err := s.db.RevokeExpiredChallenges(); err != nil {
+		return err
+	}
+	if err := s.db.CheckPKCE(code_challenge); err != nil {
+		return err
+	}
+	return s.db.RemovePKCE(code_challenge)
+}

--- a/internal/server/service/pkce.go
+++ b/internal/server/service/pkce.go
@@ -36,7 +36,7 @@ func NewPKCE(db database.Client, params Params) (s PKCEService) {
 func (s *pkceService) ComputeChallenge(code_verifier string) string {
 	hash := sha256.Sum256([]byte(code_verifier))
 	hex_hash := fmt.Sprintf("%x", hash[:])
-	return base64.RawStdEncoding.EncodeToString([]byte(hex_hash))
+	return base64.RawURLEncoding.EncodeToString([]byte(hex_hash))
 }
 
 func (s *pkceService) StoreChallenge(code_challenge string) error {

--- a/internal/server/service/user.go
+++ b/internal/server/service/user.go
@@ -40,8 +40,10 @@ type (
 	// LoginParams are used to login a user.
 	LoginParams struct {
 		Params
-		Email    string `json:"email"`
-		Password string `json:"password"`
+		Email         string `json:"email"`
+		Password      string `json:"password"`
+		CodeChallenge string `json:"code_challenge"`
+		CodeVerifier  string `json:"code_verifier"`
 	}
 
 	// UpdateUserParams are used to update a user.


### PR DESCRIPTION
This pull request add the support of the "/v2/login*" new paths, along with the new PKCE validation mechanism, recently added on the official client
Should fix issue #77 (tested on latest client)