### PR TITLE
Support reading keys from systemd credentials

### DIFF
--- a/standardfile.yml
+++ b/standardfile.yml
@@ -1,3 +1,7 @@
+# Secrets can optionally be provided by the systemd LoadCredential directive. Example:
+#   LoadCredential=secret_key:/var/lib/standardfile/secret_key.txt
+#   LoadCredential=session.secret:/var/lib/standardfile/session_secret.txt
+
 # Address to bind
 address: "localhost:5000"
 # Disable registration
@@ -7,9 +11,12 @@ show_real_version: false
 # Database folder path; empty value means current directory
 database_path: ""
 # Secret key used for JWT authentication (before 004 and 20200115)
+# If missing, will be read from $CREDENTIALS_DIRECTORY/secret_key file
 secret_key: jwt-development
 # Session used for authentication (since 004 and 20200115)
 session:
+  # If missing, will be read from $CREDENTIALS_DIRECTORY/session.secret file
   secret: paseto-development
   access_token_ttl: 1440h # 60 days expressed in Golang's time.Duration format
   refresh_token_ttl: 8760h # 1 year
+


### PR DESCRIPTION
Add support for reading the secret key and the session key from the following files:

- `$CREDENTIAL_DIRECTORY/secret_key`
- `$CREDENTIAL_DIRECTORY/session.secret`

This allows using the systemd LoadCredential directive to handle keys. For example:

```
LoadCredential=secret_key:/var/lib/standardfile/secret_key.txt
LoadCredential=session.secret:/var/lib/standardfile/session_secret.txt
```

Tested using both hardcoded secrets and LoadCredential files.