### PR TITLE
Fix e-mail and password change

### DIFF
--- a/internal/server/auth_handler_20200115_test.go
+++ b/internal/server/auth_handler_20200115_test.go
@@ -458,7 +458,7 @@ func TestRequestUpdatePassword20200115(t *testing.T) {
 
 	// If no email available, ensure no email updates
 	params["current_password"] = "yolo!"
-	r.PUT("/v1/users/419af151-78d7-4a6b-852e-cf603578eb63/attributes/credentials").SetHeader(header).SetJSON(params).Run(engine, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+	r.PUT("/v1/users/"+user.ID+"/attributes/credentials").SetHeader(header).SetJSON(params).Run(engine, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 		assert.Equal(t, http.StatusOK, r.Code)
 
 		user, err := ctrl.Database.FindUser(user.ID) // reload user
@@ -470,7 +470,7 @@ func TestRequestUpdatePassword20200115(t *testing.T) {
 	// If a new email is provided, check it's correctly updated
 	params["current_password"] = "yolo!"
 	params["new_email"] = "test@test.de"
-	r.PUT("/v1/users/419af151-78d7-4a6b-852e-cf603578eb63/attributes/credentials").SetHeader(header).SetJSON(params).Run(engine, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+	r.PUT("/v1/users/"+user.ID+"/attributes/credentials").SetHeader(header).SetJSON(params).Run(engine, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 		assert.Equal(t, http.StatusOK, r.Code)
 
 		v, err := fastjson.Parse(r.Body.String())
@@ -481,5 +481,12 @@ func TestRequestUpdatePassword20200115(t *testing.T) {
 
 		assert.Equal(t, user.Email, string(v.Get("user", "email").GetStringBytes()))
 		assert.Equal(t, user.Email, params["new_email"])
+	})
+
+	// If the user id parameter is different from the request's bearer token
+	params["current_password"] = "yolo!"
+	params["new_email"] = "test@test.de"
+	r.PUT("/v1/users/DIFFERENT-ID-THAN-IN-BEARER-TOKEN/attributes/credentials").SetHeader(header).SetJSON(params).Run(engine, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+		assert.Equal(t, http.StatusUnauthorized, r.Code)
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,6 +97,7 @@ func EchoEngine(ctrl Controller) *echo.Echo {
 	restricted.POST("/auth/sign_out", auth.Logout)
 	restricted.POST("/auth/update", auth.Update)
 	restricted.POST("/auth/change_pw", auth.UpdatePassword)
+	v1restricted.PUT("/users/:id/attributes/credentials", auth.UpdatePassword)
 
 	v1.GET("/login-params", auth.Params)
 	v1.POST("/login", auth.Login)

--- a/internal/server/service/user.go
+++ b/internal/server/service/user.go
@@ -61,6 +61,7 @@ type (
 		Identifier      string `json:"identifier"`
 		CurrentPassword string `json:"current_password"`
 		NewPassword     string `json:"new_password"`
+		NewEmail        string `json:"new_email"`
 	}
 
 	// Success handler that generates response payload.
@@ -182,6 +183,11 @@ func (s *userServiceBase) password(user *model.User, params UpdatePasswordParams
 	}
 	user.Password = pw
 	user.PasswordUpdatedAt = time.Now().Unix()
+
+	// Only update email, when parameter available
+	if params.NewEmail != "" {
+		user.Email = params.NewEmail
+	}
 
 	s.apply(user, params.UpdateUserParams)
 


### PR DESCRIPTION
Make e-mail/password change compatible with current StandardNotes client (version 3.77.1)